### PR TITLE
zen template icon fix

### DIFF
--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -25,10 +25,10 @@ do_install() {
     install -dm755 "${DESTDIR}/opt/${pkgname}/distribution"
     vinstall ${FILESDIR}/policies.json 644 "opt/${pkgname}/distribution/"
 
-    vinstall browser/chrome/icons/default/default48.png 0644 usr/share/pixmaps zen-browser.png
+    vinstall browser/chrome/icons/default/default48.png 0644 usr/share/pixmaps zen.png
     for size in 16 32 48 64 128; do
         install -d ${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps
-        vinstall browser/chrome/icons/default/default${size}.png 0644 usr/share/icons/hicolor/${size}x${size}/apps zen-browser.png
+        vinstall browser/chrome/icons/default/default${size}.png 0644 usr/share/icons/hicolor/${size}x${size}/apps zen.png
     done
 
     ln -Ts /usr/share/hunspell "${DESTDIR}/opt/${pkgname}/dictionaries"


### PR DESCRIPTION
As per zen.desktop file `Icon=zen` we change template. Otherwise icon might not be shown in `rofi` for example or `nwg-dock-hyprland` bar.

Or we can change `zen.desktop` file with `Icon=zen-browser`. But I prefer first option.